### PR TITLE
Update bindgen version and fs_extra API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ ordered-float = { version = "2.0.0", default-features = false }
 
 [build-dependencies]
 cc = { version = "1.0.58", features = ["parallel"] }
-bindgen = "0.54.1"
+bindgen = "0.55.1"
 cpp_build = "0.5.5"
 glob = "0.3.0"
 fs_extra = "1.1.0"

--- a/build.rs
+++ b/build.rs
@@ -55,6 +55,7 @@ fn prepare_tensorflow_source() -> PathBuf {
     let submodules = submodules();
 
     let copy_dir = fs_extra::dir::CopyOptions {
+        content_only: false,
         overwrite: true,
         skip_exist: false,
         buffer_size: 65536,


### PR DESCRIPTION
Your listed nightly is a few months old now. 
New nightlies show
```
error: could not compile `tfmicro`.

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: build failed
error[E0063]: missing field `content_only` in initializer of `fs_extra::dir::CopyOptions`
  --> /home/jacob/.cargo/registry/src/github.com-1ecc6299db9ec823/tfmicro-0.1.0/build.rs:57:20
   |
57 |     let copy_dir = fs_extra::dir::CopyOptions {
   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `content_only`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0063`.
```
Thoughts on supporting newer?