### PR TITLE
Update dependencies, only allow patch revisions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,20 +56,20 @@ default-target = "x86_64-unknown-linux-gnu"
 [dependencies]
 cpp = "0.5.5"
 cty = "0.2.1"
-log = { version = "0.4.8", default-features = false }
+log = { version = "0.4.11", default-features = false }
 managed = { version = "0.8.0", default-features = false }
-ordered-float = { version = "2.0.0", default-features = false }
+ordered-float = { version = "~2.0.0", default-features = false }
 
 [build-dependencies]
-cc = { version = "1.0.58", features = ["parallel"] }
+cc = { version = "~1.0.61", features = ["parallel"] }
 bindgen = "0.55.1"
 cpp_build = "0.5.5"
 glob = "0.3.0"
-fs_extra = "1.1.0"
-error-chain = "0.12.2"
+fs_extra = "~1.2.0"
+error-chain = "0.12.4"
 
 [dev-dependencies]
-env_logger = "0.7.1"
+env_logger = "0.8.1"
 itertools = "0.9.0"
 
 [features]


### PR DESCRIPTION
Only allow patch revisions by using tilde requirements for crates at 1.0 or higher