### PR TITLE
Add method to get tensorflow and its dependencies in build.rs, useful for using the crate as a git dependency

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,54 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Instant;
 
+use std::borrow::Borrow;
+use std::ffi::OsStr;
+
+fn run_command_or_fail<P, S>(dir: &str, cmd: P, args: &[S])
+where
+    P: AsRef<Path>,
+    S: Borrow<str> + AsRef<OsStr>,
+{
+    let cmd = cmd.as_ref();
+    let cmd = if cmd.components().count() > 1 && cmd.is_relative() {
+        // If `cmd` is a relative path (and not a bare command that should be
+        // looked up in PATH), absolutize it relative to `dir`, as otherwise the
+        // behavior of std::process::Command is undefined.
+        // https://github.com/rust-lang/rust/issues/37868
+        PathBuf::from(dir)
+            .join(cmd)
+            .canonicalize()
+            .expect("canonicalization failed")
+    } else {
+        PathBuf::from(cmd)
+    };
+    eprintln!(
+        "Running command: \"{} {}\" in dir: {}",
+        cmd.display(),
+        args.join(" "),
+        dir
+    );
+    let ret = Command::new(cmd).current_dir(dir).args(args).status();
+    match ret.map(|status| (status.success(), status.code())) {
+        Ok((true, _)) => return,
+        Ok((false, Some(c))) => panic!("Command failed with error code {}", c),
+        Ok((false, None)) => panic!("Command got killed"),
+        Err(e) => panic!("Command failed with error: {}", e),
+    }
+}
+
+fn check_submodules_or_checkout_from_git() {
+    if !Path::new("submodules/tensorflow/LICENSE").exists() {
+        eprintln!("Setting up submodules");
+        run_command_or_fail(".", "git", &["submodule", "update", "--init"]);
+    }
+    eprintln!("Done?");
+    if !Path::new("submodules/tensorflow/lite/micro/tools/make/downloads/flatbuffers/CONTRIBUTING.md").exists() {
+        eprintln!("Generating and fetching files using Sparkfun Edge target");
+        run_command_or_fail("submodules/tensorflow", "make", &["-f", "tensorflow/lite/micro/tools/make/Makefile", "TARGET=sparkfun_edge", "hello_world_bin"]);
+    }
+}
+
 fn manifest_dir() -> PathBuf {
     PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
 }
@@ -411,6 +459,7 @@ fn build_inline_cpp() {
 }
 
 fn main() {
+    check_submodules_or_checkout_from_git();
     bindgen_tflite_types();
     build_inline_cpp();
     cc_tensorflow_library();

--- a/build.rs
+++ b/build.rs
@@ -59,7 +59,7 @@ fn check_submodules_or_checkout_from_git() {
         run_command_or_fail(".", "git", &["submodule", "update", "--init"]);
     }
 
-    if !Path::new("submodules/tensorflow/lite/micro/tools/make/downloads/flatbuffers/CONTRIBUTING.md").exists() {
+    if !Path::new("submodules/tensorflow/tensorflow/lite/micro/tools/make/downloads/flatbuffers/CONTRIBUTING.md").exists() {
         eprintln!("Building tensorflow micro example to fetch Tensorflow dependencies");
         run_command_or_fail("submodules/tensorflow", "make", &["-f", "tensorflow/lite/micro/tools/make/Makefile", "test_micro_speech_test"]);
     }

--- a/build.rs
+++ b/build.rs
@@ -46,7 +46,7 @@ where
     );
     let ret = Command::new(cmd).current_dir(dir).args(args).status();
     match ret.map(|status| (status.success(), status.code())) {
-        Ok((true, _)) => return,
+        Ok((true, _)) => {}
         Ok((false, Some(c))) => panic!("Command failed with error code {}", c),
         Ok((false, None)) => panic!("Command got killed"),
         Err(e) => panic!("Command failed with error: {}", e),
@@ -58,10 +58,10 @@ fn check_submodules_or_checkout_from_git() {
         eprintln!("Setting up submodules");
         run_command_or_fail(".", "git", &["submodule", "update", "--init"]);
     }
-    eprintln!("Done?");
+
     if !Path::new("submodules/tensorflow/lite/micro/tools/make/downloads/flatbuffers/CONTRIBUTING.md").exists() {
-        eprintln!("Generating and fetching files using Sparkfun Edge target");
-        run_command_or_fail("submodules/tensorflow", "make", &["-f", "tensorflow/lite/micro/tools/make/Makefile", "TARGET=sparkfun_edge", "hello_world_bin"]);
+        eprintln!("Building tensorflow micro example to fetch Tensorflow dependencies");
+        run_command_or_fail("submodules/tensorflow", "make", &["-f", "tensorflow/lite/micro/tools/make/Makefile", "test_micro_speech_test"]);
     }
 }
 


### PR DESCRIPTION
Closes  #11

Fix via @mvniekerk