### PR TITLE
Add compiler flag to ignore searching for neon.h

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -169,6 +169,7 @@ trait CompilationBuilder {
             .flag("-fno-short-enums")
             .define("TF_LITE_STATIC_MEMORY", None)
             .define("TF_LITE_MCU_DEBUG_LOG", None)
+            .define("TF_LITE_DISABLE_X86_NEON", None)
             .define("GEMMLOWP_ALLOW_SLOW_SCALAR_FALLBACK", None);
 
         // warnings on by default


### PR DESCRIPTION
Refs:
    - https://github.com/tensorflow/tensorflow/issues/23440#issuecomment-436445860

	modified:   build.rs

Fixes #12

**N.B.** It should be noted that whilst the change here resolves #12 , this then leads to a further stumbling block, namely #15  