### PR TITLE
build in release mode

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -167,6 +167,8 @@ trait CompilationBuilder {
             .flag("-fno-use-cxa-atexit")
             // use a full word for enums, this should match clang's behaviour
             .flag("-fno-short-enums")
+            .define("NDEBUG", None)
+            .define("TF_LITE_STRIP_ERROR_STRINGS", None)
             .define("TF_LITE_STATIC_MEMORY", None)
             .define("TF_LITE_MCU_DEBUG_LOG", None)
             .define("GEMMLOWP_ALLOW_SLOW_SCALAR_FALLBACK", None);


### PR DESCRIPTION
I saw a ticket come through on tflite worrying about assert debug costs if you dont use the release build and I thought... hrmm. Are we building with those flags?
https://github.com/tensorflow/tensorflow/pull/44863#issuecomment-729346493

Doesnt seem like it, so adding these two defines 
https://github.com/tensorflow/tensorflow/blob/acd6f26bbaa2f747b88bfd480c6d607b4836b9ef/tensorflow/lite/micro/tools/make/Makefile#L200

drops 18812 bytes
I havent checked the cycle count, but that would be interesting

```
$ cargo +nightly size --release --example magic_wand --features="tf"
    Finished release [optimized + debuginfo] target(s) in 52.70s
   text    data     bss     dec     hex filename
 125884     172      16  126072   1ec78 magic_wand
$ cargo +nightly size --release --example magic_wand --features="tf"
    Finished release [optimized + debuginfo] target(s) in 0.31s
   text    data     bss     dec     hex filename
 107072     172      16  107260   1a2fc magic_wand
```